### PR TITLE
feat(indicator): add indicator position settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ event/
 ├── uia.rs                  -> UIA StructureChanged hook -> WM_APP_INVALIDATE_CACHE (0x101)
 └── winevent.rs             -> WinEvent EVENT_OBJECT_SHOW hook -> WM_APP_UNCOMBINE (0x100)
 virtual_desktop/
-└── indicator.rs            -> IndicatorWindow: layered window drawing desktop dots on the taskbar (winvd); click = switch desktop, Alt+click = move foreground window there
+└── indicator.rs            -> IndicatorWindow: layered window drawing desktop dots on the taskbar (winvd); left-click = switch desktop, right-click = "Move to Desktop" context menu, Alt+click = move foreground window there; placement (Auto/Left/Right) is user-configurable via Settings
 tray_icon.rs                -> Shell_NotifyIconW tray icon + context menu (Exit / Settings / Debug Console)
 setting/                    -> windows-reactor native GUI settings (hotkey capture, toggles, update check)
 logging/                    -> tracing-subscriber: rolling file + detached console via named pipes; tracing-forest format
@@ -82,6 +82,7 @@ utils.rs                    -> clean_button_name, truncate, is_system_class, is_
 - `cycle_taskbar_based: bool` (default true)
 - `hotkey_left_vk` / `hotkey_left_modifiers`, `hotkey_right_vk` / `hotkey_right_modifiers` (default Alt+`[` / Alt+`]`)
 - `desktop_indicator: bool` (default true)
+- `indicator_position: u8` (0=Auto, 1=Left, 2=Right; serde default 0 so old configs keep parsing)
 - `jump_desktop_modifiers: u32` (default Alt)
 
 **Invariant:** in `load()`, if `cycle_taskbar_based` is true then `uncombine_mode` is forced to true.
@@ -158,5 +159,6 @@ Button-to-window matching tries 4 strategies in order:
 
 - `switch_desktop` + `WindowContext::current_state()` are used to re-activate a window on the target desktop after switching (`App::handle_hotkey` -> `SwitchVirtualDesktop`).
 - `IndicatorWindow` is an owned layered window of `Shell_TrayWnd`; it gets cloaked by DWM when Task View (`Win+Tab`) opens - known limitation.
-- **Move window to desktop via indicator**: with `Alt` held, clicking a desktop dot moves the foreground window to that desktop (via `winvd::move_window_to_desktop`), switches there, and re-activates it (`force_activate`). Requires the `transmute` of the HWND into winvd's `windows`-0.58 type. Pinned (all-desktops) windows are ignored.
+- **Move window to desktop via indicator**: right-clicking a desktop dot opens a menu for exactly that dot's desktop N, with the window title in a disabled header and two short items: "Move to Desktop N" (move only) and "Move and jump to Desktop N" (move + switch + re-activate); the move-only item is grayed when the window is already on that desktop. The target window is captured before the menu temporarily drops `WS_EX_NOACTIVATE` (stored in `MOVE_TARGET_HWND` + `MOVE_TARGET_INDEX`); `force_activate` hands focus back to the app window after the menu closes, and the indicator's own class (`TaskbarSwitcherIndicator`) is filtered out of move targets so it can never be chosen as the window to move. `Alt`+click a dot is the move+jump keyboard shortcut. Requires the `transmute` of the HWND into winvd's `windows`-0.58 type. Pinned (all-desktops) windows are ignored.
+- **Indicator placement** (`AppConfig.indicator_position`: 0 Auto / 1 Left / 2 Right): in **Auto** the indicator stays clear of the system tray when the taskbar is Left-aligned (`HKCU\\...\\Explorer\\Advanced\\TaskbarAl` = 0) by anchoring just left of `TrayNotifyWnd`, otherwise it sits at the left edge. **Left**/**Right** pin it to a fixed side (Right anchors just left of the tray). Changed from the Settings GUI (Desktop Indicator -> Position), applied on `WM_APP_RELOAD_CONFIG` via `IndicatorWindow::set_position`. Position is decided at render time (no polling).
 - Hotkey auto-repeat protection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winglide"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winglide"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winglide"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["congchuahiep"]
 description = "A simple tool to improve Windows 11 navigation smoother: cycle taskbar buttons, uncombine taskbar buttons, jump to desktop,..."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub Release](https://img.shields.io/github/v/release/congchuahiep/WinGlide)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/congchuahiep/WinGlide/total)
 
-A powerful, lightweight utility built in Rust designed to enhance navigation and multitasking on Windows 11. It provides seamless keyboard-driven taskbar navigation, uncombines taskbar buttons, and offers quick virtual desktop switching.
+A powerful, lightweight utility built in Rust designed to enhance navigation and multitasking on Windows 11. It provides seamless keyboard-driven taskbar navigation, uncombines taskbar buttons, and lets you switch and move windows across virtual desktops.
 
 [📥 Download the latest](https://github.com/congchuahiep/WinGlide/releases/latest)
 
@@ -16,35 +16,16 @@ I built WinGlide to supercharge productivity by keeping your hands on the keyboa
 
 ## Features
 
-#### Cycle windows based on taskbar buttons
-
-Use `Alt + [` and `Alt + ]` to instantly cycle through open applications on your taskbar (Left/Right).
-
-<video src="https://github.com/user-attachments/assets/46faf7d0-0227-45b4-b0c4-01e6a4e78797" controls style="max-width: 100%;"></video>
-
-#### Uncombine Taskbar Buttons
-
-Prevents taskbar buttons from being grouped together, giving you individual buttons for each window.
-
-<video src="https://github.com/user-attachments/assets/c2d74899-5966-47dc-a678-f8df698e1485" controls style="max-width: 100%;"></video>
-
-#### Virtual Desktop Indicator
-
-Displays a visual indicator of your current virtual desktop position directly on the taskbar.
-
-<video src="https://github.com/user-attachments/assets/1d41a096-5139-45ff-8675-7cea09de6e1a" controls style="max-width: 100%;"></video>
-
-#### Jump to Desktop
-
-Quickly jump to a specific virtual desktop using `Alt + <index>` (starting from 1).
-
-<video src="https://github.com/user-attachments/assets/6f77acad-0fb5-42c3-adc2-1f8916c1f351" controls style="max-width: 100%;"></video>
-
-#### More Benefits
-
-- **System Tray Integration**: Easily manage the app via a convenient system tray menu.
-- **Lightweight & Fast**: Built with Rust for maximum performance and minimal resource usage (<10Mb ram usage).
-- **Free**: Free to use, why not?
+| Feature | Description | Demo |
+| --- | --- | --- |
+| **Cycle taskbar windows** | Use `Alt + [` / `Alt + ]` to instantly cycle through open applications on your taskbar (Left/Right). | <video src="https://github.com/user-attachments/assets/46faf7d0-0227-45b4-b0c4-01e6a4e78797" controls preload="metadata" width="320"></video> |
+| **Uncombine taskbar buttons** | Prevents taskbar buttons from being grouped together, giving you an individual button for each window. | <video src="https://github.com/user-attachments/assets/c2d74899-5966-47dc-a678-f8df698e1485" controls preload="metadata" width="320"></video> |
+| **Virtual desktop indicator** | A compact indicator on the taskbar shows which virtual desktop you're on; click a dot to switch. | <video src="https://github.com/user-attachments/assets/1d41a096-5139-45ff-8675-7cea09de6e1a" controls preload="metadata" width="320"></video> |
+| **Move window to desktop** | Right-click a desktop dot to move the current window there ("Move" or "Move and jump"), or `Alt` + click a dot for a quick move-and-jump. | <sub>(demo coming soon)</sub> |
+| **Jump to desktop** | Quickly jump to a specific virtual desktop using `Alt + <index>` (starting from 1). | <video src="https://github.com/user-attachments/assets/6f77acad-0fb5-42c3-adc2-1f8916c1f351" controls preload="metadata" width="320"></video> |
+| **System Tray Integration** | Easily manage the app via a convenient system tray menu. | — |
+| **Lightweight & Fast** | Built with Rust for maximum performance and minimal resource usage (<10Mb ram usage). | — |
+| **Free** | Free to use, why not? | — |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ I built WinGlide to supercharge productivity by keeping your hands on the keyboa
 
 ## Features
 
-| Feature | Description | Demo |
-| --- | --- | --- |
-| **Cycle taskbar windows** | Use `Alt + [` / `Alt + ]` to instantly cycle through open applications on your taskbar (Left/Right). | <video src="https://github.com/user-attachments/assets/46faf7d0-0227-45b4-b0c4-01e6a4e78797" controls preload="metadata" width="320"></video> |
-| **Uncombine taskbar buttons** | Prevents taskbar buttons from being grouped together, giving you an individual button for each window. | <video src="https://github.com/user-attachments/assets/c2d74899-5966-47dc-a678-f8df698e1485" controls preload="metadata" width="320"></video> |
-| **Virtual desktop indicator** | A compact indicator on the taskbar shows which virtual desktop you're on; click a dot to switch. | <video src="https://github.com/user-attachments/assets/1d41a096-5139-45ff-8675-7cea09de6e1a" controls preload="metadata" width="320"></video> |
-| **Move window to desktop** | Right-click a desktop dot to move the current window there ("Move" or "Move and jump"), or `Alt` + click a dot for a quick move-and-jump. | <sub>(demo coming soon)</sub> |
-| **Jump to desktop** | Quickly jump to a specific virtual desktop using `Alt + <index>` (starting from 1). | <video src="https://github.com/user-attachments/assets/6f77acad-0fb5-42c3-adc2-1f8916c1f351" controls preload="metadata" width="320"></video> |
-| **System Tray Integration** | Easily manage the app via a convenient system tray menu. | — |
-| **Lightweight & Fast** | Built with Rust for maximum performance and minimal resource usage (<10Mb ram usage). | — |
-| **Free** | Free to use, why not? | — |
+| Feature                       | Description                                                                                                                                        | Demo                                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cycle taskbar windows**     | Use <kbd>Alt</kbd> + <kbd>[</kbd> / <kbd>Alt</kbd> + <kbd>]</kbd> to instantly cycle through open applications on your taskbar (Left/Right).       | <video src="https://github.com/user-attachments/assets/46faf7d0-0227-45b4-b0c4-01e6a4e78797" controls preload="metadata" width="320"></video> |
+| **Uncombine taskbar buttons** | Prevents taskbar buttons from being grouped together, giving you an individual button for each window.                                             | <video src="https://github.com/user-attachments/assets/c2d74899-5966-47dc-a678-f8df698e1485" controls preload="metadata" width="320"></video> |
+| **Virtual desktop indicator** | A compact indicator on the taskbar shows which virtual desktop you're on; click a dot to switch.                                                   | <video src="https://github.com/user-attachments/assets/1d41a096-5139-45ff-8675-7cea09de6e1a" controls preload="metadata" width="320"></video> |
+| **Jump to desktop**           | Quickly jump to a specific virtual desktop using <kbd>Alt</kbd> + <kbd>&lt;index&gt;</kbd> (starting from 1).                                      | <video src="https://github.com/user-attachments/assets/6f77acad-0fb5-42c3-adc2-1f8916c1f351" controls preload="metadata" width="320"></video> |
+| **Move window to desktop**    | Right-click a desktop dot to move the current window there ("Move" or "Move and jump"), or <kbd>Alt</kbd> + click a dot for a quick move-and-jump. |                                                                                                                                               |
+| **System Tray Integration**   | Easily manage the app via a convenient system tray menu.                                                                                           |                                                                                                                                               |
+| **Lightweight & Fast**        | Built with Rust for maximum performance and minimal resource usage (<10Mb ram usage).                                                              |                                                                                                                                               |
+| **Free**                      | Why not?                                                                                                                                           |                                                                                                                                               |
 
 ## Installation
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::logging::console::{self, CONSOLE_VISIBLE};
 use crate::setting;
 use crate::taskbar::{CycleDirection, TaskbarEnumerator, UncombineManager};
 use crate::tray_icon::{TrayIcon, IDM_EXIT, IDM_SETTINGS, IDM_SHOW_CONSOLE};
-use crate::virtual_desktop::indicator::IndicatorWindow;
+use crate::virtual_desktop::indicator::{IndicatorPosition, IndicatorWindow};
 use crate::win32::window_context::WindowContext;
 
 /// Dynamic Windows message identifier "TaskbarCreated".
@@ -123,17 +123,22 @@ impl App {
         let mut tray_icon = TrayIcon::create();
         let hidden_window = Self::create_hidden_window()?;
 
-        let indicator_window = if config.desktop_indicator {
-            unsafe { Some(IndicatorWindow::new()?) }
-        } else {
-            None
-        };
-
         unsafe {
             WM_TASKBARCREATED = RegisterWindowMessageW(w!("TaskbarCreated"));
         }
 
         tray_icon.register(hidden_window.hwnd)?;
+
+        let indicator_window = if config.desktop_indicator {
+            unsafe {
+                Some(IndicatorWindow::new(IndicatorPosition::from_u8(
+                    config.indicator_position,
+                ))?)
+            }
+        } else {
+            None
+        };
+
         let uncombine_enabled = AtomicBool::new(config.uncombine_mode);
 
         Ok(Self {
@@ -298,6 +303,11 @@ impl App {
                 if let Err(e) = self.tray_icon.reregister() {
                     error!("TrayIcon reregister: {e}");
                 }
+                // The tray re-grew after our icon was re-added; re-sync the
+                // indicator so it stays clear of the tray.
+                if let Some(ind) = &self.indicator_window {
+                    ind.refresh();
+                }
                 Some(LRESULT(0))
             }
 
@@ -406,17 +416,21 @@ impl App {
             error!("Failed to reload hotkeys: {}", e);
         }
 
-        if config.desktop_indicator && self.indicator_window.is_none() {
-            unsafe {
-                match IndicatorWindow::new() {
-                    Ok(mut ind) => {
-                        ind.run();
-                        self.indicator_window = Some(ind);
+        let position = IndicatorPosition::from_u8(config.indicator_position);
+        if config.desktop_indicator {
+            match &mut self.indicator_window {
+                Some(ind) => ind.set_position(position),
+                None => unsafe {
+                    match IndicatorWindow::new(position) {
+                        Ok(mut ind) => {
+                            ind.run();
+                            self.indicator_window = Some(ind);
+                        }
+                        Err(e) => error!("Failed to create IndicatorWindow: {}", e),
                     }
-                    Err(e) => error!("Failed to create IndicatorWindow: {}", e),
-                }
+                },
             }
-        } else if !config.desktop_indicator && self.indicator_window.is_some() {
+        } else {
             self.indicator_window = None;
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,10 @@ pub struct AppConfig {
     /// Allows displaying the Desktop Indicator
     pub desktop_indicator: bool,
 
+    /// Placement of the Desktop Indicator: 0 = Auto, 1 = Left, 2 = Right
+    #[serde(default)]
+    pub indicator_position: u8,
+
     /// Modifiers for the Jump to Desktop hotkey (e.g. Alt + <number>)
     pub jump_desktop_modifiers: u32,
 }
@@ -43,6 +47,7 @@ impl Default for AppConfig {
             hotkey_right_vk: VK_OEM_6.0 as u32,
             hotkey_right_modifiers: MOD_ALT.0 as u32,
             desktop_indicator: true,
+            indicator_position: 0, // Auto
             jump_desktop_modifiers: MOD_ALT.0 as u32,
         }
     }

--- a/src/setting/setting_item.rs
+++ b/src/setting/setting_item.rs
@@ -46,11 +46,12 @@ fn render_inner_layout(
             .into()
     });
 
-    let content = vstack((title, description_el)).padding(Thickness {
-        top: 4.,
-        bottom: 4.,
-        ..Default::default()
-    });
+    // NOTE: the padding below is applied to a Border wrapper, not the vstack
+    // itself. windows-reactor only forwards `Padding` to elements that are a
+    // WinUI `Control` or `Border`; a `StackPanel`/`Grid` is a `Panel`, so a
+    // `.padding()` directly on them is silently dropped (logged as
+    // `unhandled_modifier`). Border honors Padding in layout, so wrap it.
+    let content = border(vstack((title, description_el)));
 
     // Group properties dependent on the icon to calculate once
     let (icon_el, icon_col_width, content_margin_left) = match props.icon {
@@ -68,6 +69,11 @@ fn render_inner_layout(
     grid((
         icon_el,
         content
+            .padding(Thickness {
+                top: 8.,
+                bottom: 8.,
+                ..Default::default()
+            })
             .margin(Thickness {
                 left: content_margin_left,
                 top: 0.0,

--- a/src/setting/ui.rs
+++ b/src/setting/ui.rs
@@ -238,9 +238,10 @@ fn virtual_desktop_settings(cx: &mut RenderCx) -> Element {
 
     let update_modifier = {
         let set_config = set_config.clone();
-        let config_state = config.clone();
         std::rc::Rc::new(move |mod_flag: u32, is_checked: bool| {
-            let mut new_config = config_state.clone();
+            // Load fresh config: native controls can keep a stale handler after
+            // re-renders, so never compute from captured state.
+            let mut new_config = crate::config::AppConfig::load();
             if is_checked {
                 new_config.jump_desktop_modifiers |= mod_flag;
             } else {
@@ -269,6 +270,47 @@ fn virtual_desktop_settings(cx: &mut RenderCx) -> Element {
         })
         .vertical_alignment(VerticalAlignment::Center);
 
+    // Indicator placement: a compact DropDownButton showing the current
+    // preset, with a flyout to pick Auto / Left / Right.
+    let position_label = match config.indicator_position {
+        1 => "Left",
+        2 => "Right",
+        _ => "Auto",
+    };
+    let position_action: Element = drop_down_button(position_label)
+        .menu_flyout(vec![
+            menu_item("Auto"),
+            menu_item("Left"),
+            menu_item("Right"),
+        ])
+        .on_flyout_item_click({
+            let set_config = set_config.clone();
+            move |text: String| {
+                let new_pos = match text.as_str() {
+                    "Left" => 1,
+                    "Right" => 2,
+                    _ => 0,
+                };
+                // Load fresh config: the flyout keeps a stale handler after
+                // re-renders (items unchanged => reactor skips rewiring), so
+                // relying on captured state makes re-selecting the initial
+                // value a no-op.
+                let mut new_config = crate::config::AppConfig::load();
+                if new_pos == new_config.indicator_position {
+                    return;
+                }
+                new_config.indicator_position = new_pos;
+                new_config.save();
+                set_config.call(new_config);
+                send_reload_signal();
+            }
+        })
+        .into();
+    let position_action = position_action.margin(Thickness {
+        right: 10.,
+        ..Default::default()
+    });
+
     vstack((
         body_strong("Virtual Desktop").margin(Thickness {
             bottom: 10.,
@@ -287,9 +329,8 @@ fn virtual_desktop_settings(cx: &mut RenderCx) -> Element {
                         .width(42.)
                         .on_changed({
                             let set_config = set_config.clone();
-                            let config_state = config.clone();
                             move |checked| {
-                                let mut new_config = config_state.clone();
+                                let mut new_config = crate::config::AppConfig::load();
                                 new_config.desktop_indicator = checked;
                                 new_config.save();
                                 set_config.call(new_config);
@@ -298,8 +339,26 @@ fn virtual_desktop_settings(cx: &mut RenderCx) -> Element {
                         })
                         .into(),
                 ),
-                children: None,
-                always_expand: false,
+                children: Some(vec![SettingItemProps {
+                    icon: None,
+                    title: None,
+                    description: Some(
+                        "Click a dot to switch to that desktop. Hold Alt + click to move the current window there. Right-click a dot to open a 'Move to Desktop' menu.".into(),
+                    ),
+                    action: None,
+                    children: None,
+                    always_expand: false,
+                    enabled: config.desktop_indicator,
+                }, SettingItemProps {
+                    icon: None,
+                    title: Some("Position".into()),
+                    description: Some("Placement of the indicator on the taskbar".into()),
+                    action: Some(position_action.into()),
+                    children: None,
+                    always_expand: false,
+                    enabled: config.desktop_indicator,
+                }]),
+                always_expand: true,
                 enabled: true,
             },
             cx,

--- a/src/virtual_desktop/indicator.rs
+++ b/src/virtual_desktop/indicator.rs
@@ -1,7 +1,7 @@
 //! Indicator window displaying status on the Taskbar.
 
 use std::slice::from_raw_parts_mut;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicIsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicIsize, AtomicU8, Ordering};
 
 use windows::core::{w, PCWSTR};
 use windows::Win32::Foundation::*;
@@ -15,8 +15,42 @@ use crate::win32::activate::force_activate;
 
 const WM_APP_VD_EVENT: u32 = WM_USER + 0x100;
 
+/// Gap kept between the indicator and the taskbar edge / system tray.
+const INDICATOR_MARGIN: i32 = 6;
 /// Command-ID base for the "Move to Desktop" context menu items.
 const MENU_MOVE_BASE: usize = 1000;
+
+/// Shared geometry of the virtual-desktop dots. Used both when rendering and
+/// when hit-testing the mouse, so the hover zones always line up with the dots.
+struct DotLayout {
+    radius: f32,
+    spacing: f32,
+    start_x: f32,
+}
+
+fn dot_layout(height: i32) -> DotLayout {
+    // Taskbar at 1080p is usually 48px high, at 4K (200%) it's 96px high.
+    // Binding to Taskbar height keeps the aspect ratio 100% accurate on all screens.
+    let radius = height as f32 * 0.07; // Radius = 7% height (equivalent to ~3.36px at 1080p)
+    let spacing = radius * 5.0;
+    let start_x = 10.0 + radius;
+    DotLayout {
+        radius,
+        spacing,
+        start_x,
+    }
+}
+
+/// Total window width needed so the last dot (and its hover hitbox) is fully
+/// visible. Derived from the desktop count instead of a fixed constant: adding
+/// desktops never clips the indicator, and few desktops don't leave a dead zone.
+fn indicator_width(height: i32, count: usize) -> i32 {
+    let layout = dot_layout(height);
+    let last_center = layout.start_x + count.saturating_sub(1) as f32 * layout.spacing;
+    // The last hitbox extends half a spacing past its center; the enlarged dot
+    // (1.25x radius when active/hovered) is always smaller than that.
+    (last_center + layout.spacing / 2.0).ceil() as i32 + 1
+}
 
 static HOVER_INDEX: AtomicIsize = AtomicIsize::new(-1);
 
@@ -31,6 +65,11 @@ static MOVE_TARGET_HWND: AtomicIsize = AtomicIsize::new(0);
 /// The desktop index of the dot that was right-clicked (for the move menu).
 static MOVE_TARGET_INDEX: AtomicI32 = AtomicI32::new(-1);
 
+/// Where the virtual desktop indicator is placed (see [`IndicatorPosition`]).
+/// Stored as `AtomicU8` because the static [`Self::window_proc`] needs it
+/// during `render()` without access to the struct.
+static INDICATOR_POSITION: AtomicU8 = AtomicU8::new(0);
+
 fn get_hovered_index(x: i32) -> Option<usize> {
     unsafe {
         let mut tray_rect = RECT::default();
@@ -42,22 +81,103 @@ fn get_hovered_index(x: i32) -> Option<usize> {
             return None;
         }
 
-        let radius = height as f32 * 0.08;
-        let spacing = radius * 4.5;
-        let start_x = 10.0 + radius;
-
+        let count = winvd::get_desktop_count().unwrap_or(1) as usize;
+        let layout = dot_layout(height);
+        let half_spacing = layout.spacing / 2.0;
         let px = x as f32;
 
-        let count = winvd::get_desktop_count().unwrap_or(1) as usize;
-        let half_spacing = spacing / 2.0;
         for i in 0..count {
-            let cx = start_x + (i as f32) * spacing;
+            let cx = layout.start_x + (i as f32) * layout.spacing;
             // Switch to rectangular Hit-box (like a div block), connected continuously without gaps
             if px >= cx - half_spacing && px <= cx + half_spacing {
                 return Some(i);
             }
         }
         None
+    }
+}
+
+/// Returns `true` when the taskbar alignment is "Left" (buttons start at the left
+/// edge of the taskbar). Read from `HKCU\...\Explorer\Advanced\TaskbarAl`
+/// (0 = Left, 1 = Center). Defaults to `false` (Center) when the value is absent.
+fn taskbar_alignment_left() -> bool {
+    let mut value: u32 = 1;
+    let mut size = std::mem::size_of::<u32>() as u32;
+    let res = unsafe {
+        windows::Win32::System::Registry::RegGetValueW(
+            windows::Win32::System::Registry::HKEY_CURRENT_USER,
+            w!("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+            w!("TaskbarAl"),
+            windows::Win32::System::Registry::RRF_RT_REG_DWORD,
+            None,
+            Some(&mut value as *mut _ as *mut _),
+            Some(&mut size),
+        )
+    };
+    res.is_ok() && value == 0
+}
+
+/// Left edge (screen coords) of the primary taskbar's system tray
+/// (`TrayNotifyWnd`, which contains the notification icons and the clock).
+fn tray_notify_left() -> Option<i32> {
+    unsafe {
+        let tray = FindWindowW(w!("Shell_TrayWnd"), None).ok()?;
+        let notify = FindWindowExW(Some(tray), None, w!("TrayNotifyWnd"), None).ok()?;
+        if notify.is_invalid() {
+            return None;
+        }
+        let mut rect = RECT::default();
+        GetWindowRect(notify, &mut rect).ok()?;
+        Some(rect.left)
+    }
+}
+
+/// Placement of the virtual desktop indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndicatorPosition {
+    /// Alignment-aware: left edge (Center-aligned taskbar) or just left of the
+    /// system tray (Left-aligned taskbar).
+    Auto = 0,
+    /// Fixed at the left edge of the taskbar.
+    Left = 1,
+    /// Fixed just left of the system tray (right side).
+    Right = 2,
+}
+
+impl IndicatorPosition {
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Left,
+            2 => Self::Right,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Computes the screen X where the indicator should sit, according to the
+/// configured [`IndicatorPosition`].
+fn indicator_left(taskbar: RECT, width: i32) -> i32 {
+    let position = IndicatorPosition::from_u8(INDICATOR_POSITION.load(Ordering::Relaxed));
+    let tray_left = tray_notify_left();
+    let left_of_tray = match tray_left {
+        Some(l) => (l - INDICATOR_MARGIN - width).max(taskbar.left),
+        None => taskbar.right - INDICATOR_MARGIN - width,
+    };
+
+    match position {
+        IndicatorPosition::Left => taskbar.left + 10,
+        IndicatorPosition::Right => left_of_tray,
+        IndicatorPosition::Auto => {
+            if taskbar_alignment_left() {
+                left_of_tray
+            } else {
+                taskbar.left + 10
+            }
+        }
     }
 }
 
@@ -259,7 +379,8 @@ impl IndicatorWindow {
     /// uses "Cloaking" technique to hide all Owned windows of the Taskbar. As a result,
     /// the Indicator will disappear while Task View is open, and usually only reappears when the Taskbar receives
     /// focus. This is a current technical limitation with no complete workaround yet.
-    pub unsafe fn new() -> anyhow::Result<Self> {
+    pub unsafe fn new(position: IndicatorPosition) -> anyhow::Result<Self> {
+        INDICATOR_POSITION.store(position.to_u8(), Ordering::Relaxed);
         let hinstance = GetModuleHandleW(None)?;
         let class_name = w!("TaskbarSwitcherIndicator");
 
@@ -276,15 +397,17 @@ impl IndicatorWindow {
         let mut tray_rect = RECT::default();
         let _ = GetWindowRect(taskbar_hwnd, &mut tray_rect);
         let taskbar_height = tray_rect.bottom - tray_rect.top;
+        let count = winvd::get_desktop_count().unwrap_or(1) as usize;
+        let width = indicator_width(taskbar_height, count);
 
         let hwnd = CreateWindowExW(
             WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
             class_name,
             w!("Indicator"),
             WS_POPUP | WS_VISIBLE,
-            tray_rect.left + 10,
+            indicator_left(tray_rect, width),
             tray_rect.top,
-            128,
+            width,
             taskbar_height,
             Some(taskbar_hwnd),
             None,
@@ -301,6 +424,18 @@ impl IndicatorWindow {
         Self::render(hwnd);
 
         Ok(this)
+    }
+
+    /// Changes the placement preset and re-renders the indicator.
+    pub fn set_position(&mut self, position: IndicatorPosition) {
+        INDICATOR_POSITION.store(position.to_u8(), Ordering::Relaxed);
+        Self::render(self.hwnd);
+    }
+
+    /// Re-renders the indicator, recomputing its position against the current
+    /// taskbar / system tray bounds.
+    pub fn refresh(&self) {
+        Self::render(self.hwnd);
     }
 
     /// Starts a thread to monitor Desktop switching events (Virtual Desktop).
@@ -346,12 +481,14 @@ impl IndicatorWindow {
             if let Ok(taskbar_hwnd) = FindWindowW(w!("Shell_TrayWnd"), None) {
                 let _ = GetWindowRect(taskbar_hwnd, &mut tray_rect);
             }
-            let width = 128;
             let height = tray_rect.bottom - tray_rect.top;
-
             if height <= 0 {
                 return;
             }
+
+            let count = winvd::get_desktop_count().unwrap_or(1) as usize;
+            let layout = dot_layout(height);
+            let width = indicator_width(height, count);
 
             let bmi = BITMAPINFO {
                 bmiHeader: BITMAPINFOHEADER {
@@ -390,14 +527,10 @@ impl IndicatorWindow {
                     false => (100, 100, 100),
                 };
 
-                // Taskbar at 1080p is usually 48px high, at 4K (200%) it's 96px high.
-                // Binding to Taskbar height keeps the aspect ratio 100% accurate on all screens.
-                let radius = height as f32 * 0.07; // Radius = 7% height (equivalent to ~3.36px at 1080p)
-                let spacing = radius * 5.;
-                let start_x = 10.0 + radius;
+                let radius = layout.radius;
+                let spacing = layout.spacing;
+                let start_x = layout.start_x;
                 let cy = height as f32 / 2.0;
-
-                let count = winvd::get_desktop_count().unwrap_or(1) as usize;
                 let current = winvd::get_current_desktop().ok();
                 let desktops = winvd::get_desktops().unwrap_or_default();
                 let mut current_idx = 0;
@@ -467,7 +600,7 @@ impl IndicatorWindow {
                     cy: height,
                 };
                 let mut pt_dst = POINT {
-                    x: tray_rect.left + 10,
+                    x: indicator_left(tray_rect, width),
                     y: tray_rect.top,
                 };
                 let mut blend = BLENDFUNCTION {


### PR DESCRIPTION
close #9 

- Add `indicator_position` config (0=Auto, 1=Left, 2=Right) with left/right tray-aware placement
- Refresh indicator on `TaskbarCreated` to re-sync with system tray
- Expose indicator position and move-menu docs in Settings UI
- Fix setting-item padding (wrap vstack in Border) and stale handler reloads
- Update AGENTS.md and rewrite README features table